### PR TITLE
Fix configuration property name

### DIFF
--- a/src/Model/Rule/MaxRule.php
+++ b/src/Model/Rule/MaxRule.php
@@ -14,7 +14,7 @@ class MaxRule {
 	 * @return bool
 	 */
 	public function __invoke(EntityInterface $entity, array $options): bool {
-		$limit = Configure::read('maxPerUser') ?: 1000;
+		$limit = Configure::read('Captcha.maxPerUser') ?: 1000;
 
 		/** @var \Captcha\Model\Table\CaptchasTable $repository */
 		$repository = $options['repository'];


### PR DESCRIPTION
The property must be prefixed with plugin name.
Accordingly, the doc specifies that the property should be placed under the 'Captcha' key, which is relevant.