### PR TITLE
Fix maxperuser

### DIFF
--- a/src/Controller/CaptchaController.php
+++ b/src/Controller/CaptchaController.php
@@ -4,6 +4,7 @@ namespace Captcha\Controller;
 
 use App\Controller\AppController;
 use Cake\Event\EventInterface;
+use Captcha\Model\Entity\Captcha;
 
 /**
  * @property \Captcha\Model\Table\CaptchasTable $Captchas
@@ -45,7 +46,11 @@ class CaptchaController extends AppController {
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function display($id = null) {
-		$captcha = $this->Captchas->get($id);
+		if ($id === null) {
+			$captcha = new Captcha();
+		} else {
+			$captcha = $this->Captchas->get($id);
+		}
 		$captcha = $this->Preparer->prepare($captcha);
 
 		$this->set(compact('captcha'));

--- a/src/Controller/Component/PreparerComponent.php
+++ b/src/Controller/Component/PreparerComponent.php
@@ -49,7 +49,15 @@ class PreparerComponent extends Component {
 			$captcha = $this->Captchas->patchEntity($captcha, $generated);
 		}
 
-		return $this->Captchas->save($captcha);
+		/*
+		 * Silently ignore saving failures, especially because of application rules.
+		 * This will result in the captcha to be displayed, but in the form
+		 * submission to fail intentionally since the expected result will still be
+		 * NULL.
+		 */
+		$this->Captchas->save($captcha);
+
+		return $captcha;
 	}
 
 	/**

--- a/src/Controller/Component/PreparerComponent.php
+++ b/src/Controller/Component/PreparerComponent.php
@@ -55,7 +55,9 @@ class PreparerComponent extends Component {
 		 * submission to fail intentionally since the expected result will still be
 		 * NULL.
 		 */
-		$this->Captchas->save($captcha);
+		if (!$this->Captchas->save($captcha)) {
+			$this->Captchas->delete($captcha);  // Now useless if not updated
+		}
 
 		return $captcha;
 	}

--- a/src/Controller/Component/PreparerComponent.php
+++ b/src/Controller/Component/PreparerComponent.php
@@ -5,7 +5,6 @@ namespace Captcha\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
-use Cake\Log\Log;
 
 /**
  * @internal Only for use inside this plugin's controller
@@ -50,10 +49,12 @@ class PreparerComponent extends Component {
 			$captcha = $this->Captchas->patchEntity($captcha, $generated);
 		}
 
-		// If maxPerUser is exceeded, the secret patch will fail intentionally
-		if (!$this->Captchas->save($captcha)) {
-			$this->Captchas->delete($captcha); // Now useless if not updated
-			Log::write('info', "Captcha dismissed for $captcha->ip.");
+		/*
+		 * If the captcha doesn't exist in DB, don't create it.
+		 * It will just be displayed as dummy challenge.
+		 */
+		if (!$captcha->isNew()) {
+			$this->Captchas->save($captcha);
 		}
 
 		return $captcha;

--- a/src/Controller/Component/PreparerComponent.php
+++ b/src/Controller/Component/PreparerComponent.php
@@ -5,6 +5,7 @@ namespace Captcha\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Core\Configure;
 use Cake\Event\EventDispatcherTrait;
+use Cake\Log\Log;
 
 /**
  * @internal Only for use inside this plugin's controller
@@ -49,14 +50,10 @@ class PreparerComponent extends Component {
 			$captcha = $this->Captchas->patchEntity($captcha, $generated);
 		}
 
-		/*
-		 * Silently ignore saving failures, especially because of application rules.
-		 * This will result in the captcha to be displayed, but in the form
-		 * submission to fail intentionally since the expected result will still be
-		 * NULL.
-		 */
+		// If maxPerUser is exceeded, the secret patch will fail intentionally
 		if (!$this->Captchas->save($captcha)) {
-			$this->Captchas->delete($captcha);  // Now useless if not updated
+			$this->Captchas->delete($captcha); // Now useless if not updated
+			Log::write('info', "Captcha dismissed for $captcha->ip.");
 		}
 
 		return $captcha;

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -76,6 +76,16 @@ class CaptchaBehavior extends Behavior {
 	 */
 	public function addCaptchaValidation(Validator $validator): void {
 		$validator->requirePresence('captcha_result');
+
+		$validator->add('captcha_result', [
+			'maxPerUser' => [
+				'rule' => 'validateCaptchaMaxPerUser',
+				'provider' => 'table',
+				'message' => __d('captcha', 'Too many attempts'),
+				'last' => true,
+			],
+		]);
+
 		$validator->add('captcha_result', [
 			'required' => [
 				'rule' => 'notBlank',
@@ -140,6 +150,23 @@ class CaptchaBehavior extends Behavior {
 		}
 
 		return true;
+	}
+
+	/**
+	 * @param string $value
+	 * @param array $context
+	 *
+	 * @return bool
+	 */
+	public function validateCaptchaMaxPerUser($value, $context) {
+		$captcha = $this->_getCaptcha($context['data']);
+		if (!$captcha) {
+			return false;
+		}
+
+		$expected = $captcha->result;
+
+		return ($expected !== null) && ($expected !== '');
 	}
 
 	/**

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -153,11 +153,12 @@ class CaptchaBehavior extends Behavior {
 		if (!$captcha) {
 			return false;
 		}
+
+		$this->_captchasTable->markUsed($captcha);
+
 		if ((string)$value !== $captcha->result) {
 			return false;
 		}
-
-		$this->_captchasTable->markUsed($captcha);
 
 		return true;
 	}

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -76,7 +76,6 @@ class CaptchaBehavior extends Behavior {
 	 */
 	public function addCaptchaValidation(Validator $validator): void {
 		$validator->requirePresence('captcha_result');
-
 		$validator->add('captcha_result', [
 			'maxPerUser' => [
 				'rule' => 'validateCaptchaMaxPerUser',
@@ -160,13 +159,8 @@ class CaptchaBehavior extends Behavior {
 	 */
 	public function validateCaptchaMaxPerUser($value, $context) {
 		$captcha = $this->_getCaptcha($context['data']);
-		if (!$captcha) {
-			return false;
-		}
 
-		$expected = $captcha->result;
-
-		return ($expected !== null) && ($expected !== '');
+		return (bool)$captcha;
 	}
 
 	/**

--- a/src/Model/Rule/MaxRule.php
+++ b/src/Model/Rule/MaxRule.php
@@ -4,6 +4,7 @@ namespace Captcha\Model\Rule;
 
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\Log\Log;
 
 class MaxRule {
 
@@ -19,7 +20,12 @@ class MaxRule {
 		/** @var \Captcha\Model\Table\CaptchasTable $repository */
 		$repository = $options['repository'];
 
-		return $repository->getCount($entity->ip, $entity->session_id) < (int)$limit;
+		$success = $repository->getCount($entity->ip, $entity->session_id) < (int)$limit;
+		if (!$success) {
+			Log::write('info', "Too many captchas attempts for $entity->ip");
+		}
+
+		return $success;
 	}
 
 }

--- a/src/Model/Table/CaptchasTable.php
+++ b/src/Model/Table/CaptchasTable.php
@@ -161,7 +161,7 @@ class CaptchasTable extends Table {
 	public function markUsed($captcha): bool {
 		$captcha->used = new FrozenTime();
 
-		return (bool)$this->save($captcha);
+		return (bool)$this->save($captcha, ['checkRules' => false]);
 	}
 
 }

--- a/src/Model/Table/CaptchasTable.php
+++ b/src/Model/Table/CaptchasTable.php
@@ -88,7 +88,7 @@ class CaptchasTable extends Table {
 	 * @return \Cake\ORM\RulesChecker
 	 */
 	public function buildRules(RulesChecker $rules): RulesChecker {
-		$rules->addCreate(new MaxRule());
+		$rules->addUpdate(new MaxRule());
 
 		return $rules;
 	}

--- a/src/Model/Table/CaptchasTable.php
+++ b/src/Model/Table/CaptchasTable.php
@@ -2,7 +2,6 @@
 
 namespace Captcha\Model\Table;
 
-use BadMethodCallException;
 use Cake\Core\Configure;
 use Cake\Database\Schema\TableSchemaInterface;
 use Cake\I18n\FrozenTime;
@@ -88,7 +87,7 @@ class CaptchasTable extends Table {
 	 * @return \Cake\ORM\RulesChecker
 	 */
 	public function buildRules(RulesChecker $rules): RulesChecker {
-		$rules->addUpdate(new MaxRule());
+		$rules->addCreate(new MaxRule());
 
 		return $rules;
 	}
@@ -99,7 +98,7 @@ class CaptchasTable extends Table {
 	 *
 	 * @throws \BadMethodCallException
 	 *
-	 * @return int
+	 * @return int|null
 	 */
 	public function touch($sessionId, $ip) {
 		$probability = (int)Configure::read('Captcha.cleanupProbability') ?: 10;
@@ -114,11 +113,11 @@ class CaptchasTable extends Table {
 				'validate' => false,
 			],
 		);
-		if (!$this->save($captcha)) {
-			throw new BadMethodCallException('Sth went wrong: ' . print_r($captcha->getErrors(), true));
+		if ($this->save($captcha)) {
+			return $captcha->id;
 		}
 
-		return $captcha->id;
+		return null;
 	}
 
 	/**
@@ -161,7 +160,7 @@ class CaptchasTable extends Table {
 	public function markUsed($captcha): bool {
 		$captcha->used = new FrozenTime();
 
-		return (bool)$this->save($captcha, ['checkRules' => false]);
+		return (bool)$this->save($captcha);
 	}
 
 }

--- a/src/View/Helper/CaptchaHelper.php
+++ b/src/View/Helper/CaptchaHelper.php
@@ -117,7 +117,7 @@ class CaptchaHelper extends Helper {
 	}
 
 	/**
-	 * @return int
+	 * @return int|null
 	 */
 	protected function _getId() {
 		if ($this->_id) {

--- a/tests/TestCase/Model/Table/CaptchasTableTest.php
+++ b/tests/TestCase/Model/Table/CaptchasTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Captcha\Test\TestCase\Model\Table;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 
 class CaptchasTableTest extends TestCase {
@@ -29,6 +30,8 @@ class CaptchasTableTest extends TestCase {
 		parent::setUp();
 		$config = $this->getTableLocator()->exists('Captchas') ? [] : ['className' => 'Captcha\Model\Table\CaptchasTable'];
 		$this->Captchas = $this->getTableLocator()->get('Captchas', $config);
+
+		Configure::delete('Captcha.maxPerUser');
 	}
 
 	/**
@@ -48,6 +51,22 @@ class CaptchasTableTest extends TestCase {
 	public function testTouch() {
 		$sessionId = 'cli';
 		$ip = '123';
+		$result = $this->Captchas->touch($sessionId, $ip);
+
+		$this->assertNotEmpty($result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testTouchTooManyAttemps() {
+		$sessionId = 'cli';
+		$ip = '123';
+
+		// Simulate too many attempts by setting the limit to zero
+		Configure::write('Captcha.maxPerUser', 0);
+
+		// Shouldn't throw an exception
 		$result = $this->Captchas->touch($sessionId, $ip);
 
 		$this->assertNotEmpty($result);


### PR DESCRIPTION
Fixes #31 

## Purpose

When `maxPerUser`is exceeded, an exception is thrown unintentionally.
The expected behavior in this case could be to :

1. display the captcha. This may be desired in order to avoid lacks in the view, especially if the captcha is integrated in a sentence like _"What is the resuilt of...?"_
2. display a validation error indicating for instance _"too many attempts"_
3. fail on every form submission.

## How to do it

`MaxRule` has been changed from a _create_ rule to an _update_ rule.
This way, the captcha **can** be created by `CaptchasTable` but its result won't ever be saved by `PreparerComponent` when generating the image and its solution. `PreparerComponent` sets anyway the updated (and unsaved) captcha in the view so that it can be displayed in the view.

A new validation rule checks if the captcha's expected result is null, in which case it means that it will fail anyway on next submission. This is intended to display an error message, so that the user understands why every attempts are denied yet.

## Observation

Captchas were marked as used on success only. I think they should be marked as used on any attempt, because a new one will be generated on page reload.