### PR TITLE
Enhance maxPerUser

### DIFF
--- a/docs/Active.md
+++ b/docs/Active.md
@@ -148,5 +148,5 @@ You can also use a simple cron job that does it. Set `cleanupProbability` to `0`
 The `minTime` is by default 2 seconds and make sure you cannot auto-post a form too fast.
 
 One should also include a throttle limit, so you cannot fill up the DB.
-The built in mechanism is a `maxPerUser` value (defaults to 1000) which prevents entering more than this amount per ip or session.
-If a form gets built and sent too often, those captcha results will never validate then (as their result has not been persisted anymore due to this rate limit).
+The built in mechanism is a `maxPerUser` value (defaults to 100) which prevents entering more than this amount per ip or session.
+If a form gets built and failed too often, those captcha results will never validate then for one hour (as their result has not been persisted anymore due to this rate limit).

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -84,14 +84,6 @@ class CaptchaBehavior extends Behavior {
 				'last' => true,
 			],
 		]);
-		$validator->add('captcha_result', [
-			'maxPerUser' => [
-				'rule' => 'validateCaptchaMaxPerUser',
-				'provider' => 'table',
-				'message' => __d('captcha', 'Too many attempts'),
-				'last' => true,
-			],
-		]);
 
 		$this->_engine->buildValidator($validator);
 		if ($this->getConfig('minTime')) {
@@ -150,18 +142,6 @@ class CaptchaBehavior extends Behavior {
 		}
 
 		return true;
-	}
-
-	/**
-	 * @param string $value
-	 * @param array $context
-	 *
-	 * @return bool
-	 */
-	public function validateCaptchaMaxPerUser($value, $context) {
-		$captcha = $this->_getCaptcha($context['data']);
-
-		return (bool)$captcha;
 	}
 
 	/**

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -175,12 +175,11 @@ class CaptchaBehavior extends Behavior {
 		if (!$captcha) {
 			return false;
 		}
-
-		$this->_captchasTable->markUsed($captcha);
-
 		if ((string)$value !== $captcha->result) {
 			return false;
 		}
+
+		$this->_captchasTable->markUsed($captcha);
 
 		return true;
 	}

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -80,6 +80,7 @@ class CaptchaBehavior extends Behavior {
 		$validator->add('captcha_result', [
 			'required' => [
 				'rule' => 'notBlank',
+				'message' => __d('captcha', 'Please solve the riddle'),
 				'last' => true,
 			],
 		]);

--- a/src/Model/Rule/MaxRule.php
+++ b/src/Model/Rule/MaxRule.php
@@ -15,7 +15,7 @@ class MaxRule {
 	 * @return bool
 	 */
 	public function __invoke(EntityInterface $entity, array $options): bool {
-		$limit = Configure::read('Captcha.maxPerUser') ?: 1000;
+		$limit = Configure::read('Captcha.maxPerUser') ?: 100;
 
 		/** @var \Captcha\Model\Table\CaptchasTable $repository */
 		$repository = $options['repository'];

--- a/src/Model/Table/CaptchasTable.php
+++ b/src/Model/Table/CaptchasTable.php
@@ -128,7 +128,14 @@ class CaptchasTable extends Table {
 	 */
 	public function getCount($ip, $sessionId) {
 		return $this->find()
-			->where(['used IS' => null, 'or' => ['ip' => $ip, 'session_id' => $sessionId]])
+			->where([
+				'used IS' => null,
+				'created >' => FrozenTime::now()->subHour(),
+				'or' => [
+					'ip' => $ip,
+					'session_id' => $sessionId,
+				],
+			])
 			->count();
 	}
 


### PR DESCRIPTION
## Various purposes

This completes #33 

- Set a custom error message for `notBlank` rule.
- Let failed captchas as unused. They'll count in `maxPerUser` limit.
- Remove the useless `maxPerUser` validation rule. The same test is already processed by `maxTime` rule, and there's no need of an error message in this case since the rule is intended to block bots only.
- Lower the default value of `maxPerUser`. 1000 is too high for the default engine and could lead to successful forms using random values for captchas.