### PR TITLE
Improve SimpleEngine

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -4,7 +4,8 @@
 
 return [
 	'Captcha' => [
-		'maxPerUser' => 100, // Total stored captchas
+		'maxPerUser' => 100, // Total stored captchas per user
+		'deadlockMinutes' => 60, // How long at most to block a user who generated too much captchas
 		'cleanupProbability' => 10, // 0...100 - Use 0 if you use a cronjob to manually garbage collect
 	],
 ];

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -4,7 +4,7 @@
 
 return [
 	'Captcha' => [
-		'maxPerUser' => 1000, // Total stored captchas
+		'maxPerUser' => 100, // Total stored captchas
 		'cleanupProbability' => 10, // 0...100 - Use 0 if you use a cronjob to manually garbage collect
 	],
 ];

--- a/docs/Active.md
+++ b/docs/Active.md
@@ -150,3 +150,5 @@ The `minTime` is by default 2 seconds and make sure you cannot auto-post a form 
 One should also include a throttle limit, so you cannot fill up the DB.
 The built in mechanism is a `maxPerUser` value (defaults to 100) which prevents entering more than this amount per ip or session.
 If a form gets built and failed too often, those captcha results will never validate then for one hour (as their result has not been persisted anymore due to this rate limit).
+The user will be blocked at most for 1 hour, customizable with `deadlockMinutes` config parameter. The user may submit new forms earlier depending on client IP and session ID.
+Note that this feature doesn't prevent the user to solve more captchas. Only unused or failed captchas throttling the DB are limited this way.

--- a/src/Engine/Math/SimpleMath.php
+++ b/src/Engine/Math/SimpleMath.php
@@ -8,7 +8,7 @@ class SimpleMath implements MathInterface {
 	 * @var array<string, mixed>
 	 */
 	protected $_defaultConfig = [
-		'complexity' => 2,
+		'complexity' => 10,
 	];
 
 	/**
@@ -28,9 +28,9 @@ class SimpleMath implements MathInterface {
 		$this->_config = $config + $this->_defaultConfig;
 		$this->data[0] = $this->_randomNumber();
 		$this->data[1] = $this->_randomOperator();
-		$this->data[2] = $this->_randomNumber();
+		$this->data[2] = $this->_randomNumber(1);
 		while ($this->data[2] === $this->data[0]) {
-			$this->data[2] = $this->_randomNumber();
+			$this->data[2] = $this->_randomNumber(10);
 		}
 
 		if ($this->data[1] === '-' && $this->data[2] > $this->data[0]) {
@@ -67,10 +67,15 @@ class SimpleMath implements MathInterface {
 	}
 
 	/**
+	 * @param int $complexity
 	 * @return int
 	 */
-	protected function _randomNumber() {
-		return random_int(1, 10 * $this->_config['complexity']);
+	protected function _randomNumber(int $complexity = 0) {
+		if (!$complexity) {
+			$complexity = $this->_config['complexity'];
+		}
+
+		return random_int(1, 10 * $complexity);
 	}
 
 	/**

--- a/src/Engine/Math/SimpleMath.php
+++ b/src/Engine/Math/SimpleMath.php
@@ -8,7 +8,7 @@ class SimpleMath implements MathInterface {
 	 * @var array<string, mixed>
 	 */
 	protected $_defaultConfig = [
-		'complexity' => 10,
+		'complexity' => 2,
 	];
 
 	/**
@@ -28,7 +28,7 @@ class SimpleMath implements MathInterface {
 		$this->_config = $config + $this->_defaultConfig;
 		$this->data[0] = $this->_randomNumber();
 		$this->data[1] = $this->_randomOperator();
-		$this->data[2] = $this->_randomNumber(1);
+		$this->data[2] = $this->_randomNumber(10);
 		while ($this->data[2] === $this->data[0]) {
 			$this->data[2] = $this->_randomNumber(10);
 		}
@@ -67,15 +67,15 @@ class SimpleMath implements MathInterface {
 	}
 
 	/**
-	 * @param int $complexity
+	 * @param int $max
 	 * @return int
 	 */
-	protected function _randomNumber(int $complexity = 0) {
-		if (!$complexity) {
-			$complexity = $this->_config['complexity'];
+	protected function _randomNumber(int $max = 0) {
+		if (!$max) {
+			$max = 50 * $this->_config['complexity'];
 		}
 
-		return random_int(1, 10 * $complexity);
+		return random_int(1, $max);
 	}
 
 	/**

--- a/src/Model/Table/CaptchasTable.php
+++ b/src/Model/Table/CaptchasTable.php
@@ -127,10 +127,12 @@ class CaptchasTable extends Table {
 	 * @return int
 	 */
 	public function getCount($ip, $sessionId) {
+		$deadlockMinutes = Configure::read('Captcha.deadlockMinutes') ?? 60;
+
 		return $this->find()
 			->where([
 				'used IS' => null,
-				'created >' => FrozenTime::now()->subHour(),
+				'created >' => FrozenTime::now()->subMinutes($deadlockMinutes),
 				'or' => [
 					'ip' => $ip,
 					'session_id' => $sessionId,


### PR DESCRIPTION
## SimpleEngine

Improve `SimpleEngine` to make it harder to guess with random values.

## Customizable deadlock duration

Allow custom deadlock duration in case `maxPerUser` is exceeded.
However, this is an "at most" threshold, since the client IP or the session ID may change in the meanwhile.

## Resigned : display smart error message as the captcha image.

No idea if this feature would really be useful, but I scratched my head to display simple text as an image. I wrote (smelling) code which doesn't even pass coding standards.
I've given up because I don't know how to do and have already wasted too much time for this detail. You can have a look to https://github.com/zachee54/cakephp-captcha/commit/f3d1cdd938375f0860ceac780e84171da2c540a8 if you're interested in.