### PR TITLE
Display maxPerUser error message

### DIFF
--- a/src/Engine/Math/SimpleMath.php
+++ b/src/Engine/Math/SimpleMath.php
@@ -75,7 +75,7 @@ class SimpleMath implements MathInterface {
 			$max = 50 * $this->_config['complexity'];
 		}
 
-		return random_int(1, $max);
+		return random_int(1, (int)$max);
 	}
 
 	/**

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -85,6 +85,15 @@ class CaptchaBehavior extends Behavior {
 			],
 		]);
 
+		$validator->add('captcha_result', [
+			'maxPerUser' => [
+				'rule' => 'validateCaptchaMaxPerUser',
+				'provider' => 'table',
+				'message' => __d('captcha', 'Please retry later'),
+				'last' => true,
+			],
+		]);
+
 		$this->_engine->buildValidator($validator);
 		if ($this->getConfig('minTime')) {
 			$validator->add('captcha_result', [
@@ -106,6 +115,17 @@ class CaptchaBehavior extends Behavior {
 				],
 			]);
 		}
+	}
+
+	/**
+	 * @param string $value
+	 * @param array $context
+	 *
+	 * @return bool
+	 */
+	public function validateCaptchaMaxPerUser($value, $context) {
+		// If no id was provided, the captcha was dummy due to MaxRule failure
+		return !empty($context['data']['captcha_id']);
 	}
 
 	/**


### PR DESCRIPTION
After many useless attempts, I finally found a solution.

The lack of captcha_id in POST data is the signature of previous `MaxRule` failure. Then we can display an error message after form submission (and make it fail BTW).

### Other (failed) ideas

It wasn't possible to display a similar message on first load because `FormHelper` displays an error only if the context has an error on this field. And we can't write in the context from the plugin.

It was also impossible to re-check `MaxRule` on form submission, or another method implementing the same checks.
On form submission, the component may not be called. Only the table and the behavior get called for sure. However, neither of them has access to HTTP request, which contains the session ID and the client IP. Without these informations, we can't run the checks.