### PR TITLE
Force empty value for captcha_id

### DIFF
--- a/src/View/Helper/CaptchaHelper.php
+++ b/src/View/Helper/CaptchaHelper.php
@@ -68,7 +68,7 @@ class CaptchaHelper extends Helper {
 		$id = $this->_getId();
 
 		$html = $this->control($options);
-		$html .= $this->Form->control('captcha_id', ['type' => 'hidden', 'value' => $id]);
+		$html .= $this->Form->control('captcha_id', ['type' => 'hidden', 'value' => $id ?? '']);
 		$html .= $this->passive();
 
 		return $html;


### PR DESCRIPTION
## Issue

When creating too many forms and answering wrong captcha results, the displayed message is still _"The solution is not correct"_ instead of _"Please retry later"_.

## Cause

If the catcha doesn't exist, the fetched id is null. However, passing a null value to `FormHelper` is the default. As a consequence, `FormHelper` keeps the posted `captcha_id`, if any. The form passes then maxPerUser validation rule while it should fail.

## Patch

Replace null id by an empty string on `FormHelper::control()` call for `captcha_id` field.