### PR TITLE
Add admin backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ For the match captcha, make sure you got the gd lib installed:
 
 ## Usage
 See [Docs](docs/).
+
+## Admin Backend
+A self-contained admin backend ships with the plugin. It mounts at `/admin/captcha/` by default and provides:
+
+- Health dashboard with stat tiles and an hourly heatmap
+- Per-IP investigation pages and currently rate-limited list
+- One-click maintenance: cleanup, hard reset, per-IP reset, rate-limit cache wipe
+
+Access is **deny-by-default** — register a `Captcha.adminAccess` closure to grant access. See [docs/Admin.md](docs/Admin.md) for setup.

--- a/config/Migrations/20260427150000_AddSolvedToCaptchas.php
+++ b/config/Migrations/20260427150000_AddSolvedToCaptchas.php
@@ -1,0 +1,31 @@
+<?php
+
+use Migrations\BaseMigration;
+
+class AddSolvedToCaptchas extends BaseMigration {
+
+	/**
+	 * @return void
+	 */
+	public function up() {
+		$table = $this->table('captchas');
+		$table->addColumn('solved', 'boolean', [
+			'default' => null,
+			'null' => true,
+			'after' => 'used',
+		]);
+		$table->addIndex(['solved', 'created'], ['name' => 'idx_solved_created']);
+		$table->update();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function down() {
+		$table = $this->table('captchas');
+		$table->removeIndex(['solved', 'created']);
+		$table->removeColumn('solved');
+		$table->update();
+	}
+
+}

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -14,5 +14,16 @@ return [
 			'scope' => 'ip_session', // 'ip_session' or 'ip'
 			'cache' => 'default',
 		],
+
+		// Admin backend (mounted at /<adminPrefix><adminRoutePath> — default /admin/captcha)
+		'adminPrefix' => 'Admin', // Route prefix to mount the admin under
+		'adminRoutePath' => '/captcha', // Path segment under the prefix
+		'adminLayout' => null, // null = plugin layout, false = host layout, string = custom layout name
+
+		// REQUIRED for the admin backend. Default is deny — the closure must return true to allow access.
+		// 'adminAccess' => function (\Cake\Http\ServerRequest $request): bool {
+		//     $identity = $request->getAttribute('identity');
+		//     return $identity !== null && in_array('admin', (array)($identity->roles ?? []), true);
+		// },
 	],
 ];

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -1,0 +1,113 @@
+# Admin Backend
+
+The plugin ships with a self-contained admin backend that gives you health, abuse-signal, and maintenance views for the captchas table without dropping into SQL.
+
+## Routing
+
+By default the admin mounts at `/admin/captcha/` (controlled by two `Configure` keys):
+
+```php
+// config/app.php (or wherever you keep Captcha config)
+'Captcha' => [
+    'adminPrefix' => 'Admin',     // Route prefix
+    'adminRoutePath' => '/captcha', // Path under the prefix
+    // ...
+],
+```
+
+Both keys are optional — leave them at the defaults and you get `/admin/captcha/`.
+
+## Authorization (deny by default)
+
+The admin backend is **deny by default**. You must register an access closure that returns `true` for the requests you want to let through. The closure receives the current `ServerRequest` so you can inspect identity, roles, IP, headers, anything.
+
+```php
+// config/bootstrap.php (or your Application::bootstrap())
+use Cake\Http\ServerRequest;
+use Cake\Core\Configure;
+
+Configure::write('Captcha.adminAccess', function (ServerRequest $request): bool {
+    $identity = $request->getAttribute('identity');
+    return $identity !== null && in_array('admin', (array)($identity->roles ?? []), true);
+});
+```
+
+If `Captcha.adminAccess` is not set, every admin URL responds with `403 Forbidden`.
+
+This deliberately diverges from sister plugins (cakephp-queue, CakePHP-DatabaseLog) which assume the host app secures the prefix. Captcha is security-adjacent and accidental exposure is harmful, so a closure is required.
+
+## Layout
+
+The admin uses a self-contained Bootstrap 5 layout shipped with the plugin (`Captcha.captcha-admin`). To use your host app's layout instead, set:
+
+```php
+'Captcha' => [
+    'adminLayout' => false,         // host layout
+    // or 'adminLayout' => 'MyApp.admin',
+],
+```
+
+## Features
+
+### Dashboard (`/admin/captcha/`)
+
+- **Stat tiles**: Open · Solved (24h) · Failed (24h) · Solve rate · Expired (no attempt) · Throttled now
+- **Hourly heatmap**: 7×24 grid colored by issued count, with `solved/failed` breakdown on hover
+- **Engine + config snapshot**: which engine is active, plus the load-bearing config values
+- **Maintenance strip**: `Run cleanup now`, `Hard reset (truncate)` — both `confirm`-gated `postLink`s
+
+### IPs (`/admin/captcha/ips/`)
+
+- Four leaderboards: Top issued · Top solved · Top failed · Currently rate-limited
+- Window selector: 24h / 7d
+- Per-row actions: Unblock (clear rate-limit cache for that IP across known sessions) · Delete (remove all captchas for that IP)
+
+### Per-IP detail (`/admin/captcha/ips/view/{ip}`)
+
+- Header tile counts for that IP (24h)
+- Paginated table of recent captchas for the IP, with `solved` icon, `created`, `used`, truncated session_id and uuid
+
+### Engine (`/admin/captcha/engine`)
+
+Read-only list of registered engines (`MathEngine`, `NullEngine`, plus any custom one you set in `Captcha.engine`). Active engine highlighted.
+
+### Preview (`/admin/captcha/preview`)
+
+Renders a sample captcha through the configured engine for verification. The preview does **not** create a `captchas` table row — it only invokes the engine's `generate()` method. Useful when sanity-checking a config change without touching a real form.
+
+### Config (`/admin/captcha/config`)
+
+Read-only flat dump of every `Captcha.*` key with its resolved value. Configure isn't runtime-editable, so this is intentionally view-only.
+
+## Data model
+
+The admin reads from the existing `captchas` table plus one new column:
+
+| Column | Type | Why |
+|---|---|---|
+| `solved` | nullable boolean | `null` = issued/no attempt yet, `true` = correct answer, `false` = wrong answer. Set during verification. |
+
+A migration is shipped:
+
+```
+bin/cake migrations migrate -p Captcha
+```
+
+Existing rows backfill to `null` (they predate the tracking). Solve-rate computations exclude `null` rows so historical data does not skew the ratio.
+
+## Currently-rate-limited derivation
+
+The verify rate-limit lives in `Cache`, keyed on `sha1(ip|session)` plus a time bucket. Cache keys are not reversible to recover the original IP, and not all cache backends support iteration — so the dashboard derives the throttled-IPs list from the captchas table directly:
+
+```sql
+SELECT ip, COUNT(*) AS failed_in_window
+FROM captchas
+WHERE solved = false
+  AND created > NOW() - INTERVAL :window SECOND
+GROUP BY ip
+HAVING failed_in_window >= :max_failures
+```
+
+`:window` and `:max_failures` come from `Captcha.verifyRateLimit`. This is a *good-enough proxy* for the cache state — admins use it to spot patterns and unblock, not as a source of truth.
+
+`Unblock` (the per-IP postLink) re-derives the `(ip, session_id)` tuples from the captchas table and deletes the corresponding cache keys.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,12 @@ This plugin ships with two different types of captchas:
 
 They can also be combined for maximum captcha effectiveness.
 
+## Admin Backend
+
+For monitoring captcha health and investigating abuse, the plugin ships with a self-contained admin backend:
+
+- [Admin](Admin.md): Setup, routing, auth, and feature reference
+
 
 ## Basic Usage
 Using the default MathEngine we can simply attach the behavior to the Table class.

--- a/src/Cache/RateLimitKey.php
+++ b/src/Cache/RateLimitKey.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Cache;
+
+/**
+ * Builds the cache key used by the verify rate limiter.
+ *
+ * The same algorithm is used by the captcha behavior at write time and by
+ * the admin backend when reading or wiping keys for a given (ip, session)
+ * tuple. Keep both callers in sync via this single source of truth.
+ */
+class RateLimitKey {
+
+	/**
+	 * @var string
+	 */
+	public const SCOPE_IP = 'ip';
+
+	/**
+	 * @var string
+	 */
+	public const SCOPE_IP_SESSION = 'ip_session';
+
+	/**
+	 * @var string
+	 */
+	public const KEY_PREFIX = 'captcha_verify_rate_limit_';
+
+	/**
+	 * @param string $ip
+	 * @param string $sessionId
+	 * @param string $scope `ip` or `ip_session`
+	 * @param int $window Seconds (must be >= 1).
+	 * @param int|null $now Optional timestamp override for tests.
+	 *
+	 * @return string
+	 */
+	public static function build(
+		string $ip,
+		string $sessionId,
+		string $scope,
+		int $window,
+		?int $now = null,
+	): string {
+		$keyData = $scope === static::SCOPE_IP ? $ip : $ip . '|' . $sessionId;
+		$window = max($window, 1);
+		$bucket = (int)floor(($now ?? time()) / $window);
+
+		return static::KEY_PREFIX . sha1($keyData) . '_' . $bucket;
+	}
+
+}

--- a/src/CaptchaPlugin.php
+++ b/src/CaptchaPlugin.php
@@ -3,6 +3,7 @@
 namespace Captcha;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\Configure;
 use Cake\Routing\Route\DashedRoute;
 use Cake\Routing\RouteBuilder;
 
@@ -26,6 +27,15 @@ class CaptchaPlugin extends BasePlugin {
 		$routes->plugin('Captcha', ['path' => '/captcha'], function (RouteBuilder $routes): void {
 			$routes->setExtensions(['png', 'jpg']);
 			$routes->fallbacks(DashedRoute::class);
+		});
+
+		$adminPrefix = (string)Configure::read('Captcha.adminPrefix', 'Admin');
+		$adminPath = (string)Configure::read('Captcha.adminRoutePath', '/captcha');
+		$routes->prefix($adminPrefix, function (RouteBuilder $routes) use ($adminPath): void {
+			$routes->plugin('Captcha', ['path' => $adminPath], function (RouteBuilder $routes): void {
+				$routes->connect('/', ['controller' => 'Captcha', 'action' => 'index']);
+				$routes->fallbacks(DashedRoute::class);
+			});
 		});
 	}
 

--- a/src/Controller/Admin/CaptchaAdminAppController.php
+++ b/src/Controller/Admin/CaptchaAdminAppController.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Controller\Admin;
+
+use App\Controller\AppController;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Closure;
+
+/**
+ * Base controller for the Captcha admin backend.
+ *
+ * Default policy is deny — `Captcha.adminAccess` must be a closure that
+ * returns true for the current request to grant access. This is intentional:
+ * captcha is security-adjacent and accidental exposure is harmful.
+ */
+class CaptchaAdminAppController extends AppController {
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void {
+		parent::initialize();
+
+		if (!$this->components()->has('Flash')) {
+			$this->loadComponent('Flash');
+		}
+
+		$layout = Configure::read('Captcha.adminLayout');
+		if ($layout !== false) {
+			$this->viewBuilder()->setLayout(is_string($layout) ? $layout : 'Captcha.captcha-admin');
+		}
+	}
+
+	/**
+     * @param \Cake\Event\EventInterface $event
+     * @throws \Cake\Http\Exception\ForbiddenException When access is denied.
+     * @return void
+	 */
+	public function beforeFilter(EventInterface $event): void {
+		parent::beforeFilter($event);
+
+		if ($this->components()->has('Authorization') && method_exists($this->components()->get('Authorization'), 'skipAuthorization')) {
+			$this->components()->get('Authorization')->skipAuthorization();
+		}
+
+		$gate = Configure::read('Captcha.adminAccess');
+		if (!($gate instanceof Closure)) {
+			throw new ForbiddenException(__d('captcha', 'Captcha admin backend is not configured. Set Captcha.adminAccess to a Closure.'));
+		}
+		if ($gate($this->request) !== true) {
+			throw new ForbiddenException(__d('captcha', 'Captcha admin access denied.'));
+		}
+	}
+
+}

--- a/src/Controller/Admin/CaptchaController.php
+++ b/src/Controller/Admin/CaptchaController.php
@@ -1,0 +1,290 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Controller\Admin;
+
+use Cake\Core\App;
+use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
+use Cake\I18n\DateTime;
+use Captcha\Engine\EngineInterface;
+use Captcha\Engine\MathEngine;
+use Captcha\Engine\NullEngine;
+
+/**
+ * Captcha admin dashboard, config & engine views, maintenance actions.
+ *
+ * @property \Captcha\Model\Table\CaptchasTable $Captchas
+ */
+class CaptchaController extends CaptchaAdminAppController {
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $defaultTable = 'Captcha.Captchas';
+
+	/**
+	 * Window sizes (seconds) used by the dashboard tiles.
+     * @var int
+	 */
+	protected const WINDOW_24H = 86400;
+
+	/**
+     * @var int
+     */
+	protected const WINDOW_7D = 604800;
+
+	/**
+	 * @return void
+	 */
+	public function index(): void {
+		$tiles24h = $this->aggregateCounts(static::WINDOW_24H);
+		$tiles7d = $this->aggregateCounts(static::WINDOW_7D);
+		$throttledIps = $this->countThrottledIps();
+		$heatmap = $this->buildHeatmap();
+		$snapshot = $this->buildSnapshot();
+
+		$this->set(compact('tiles24h', 'tiles7d', 'throttledIps', 'heatmap', 'snapshot'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function config(): void {
+		$config = (array)Configure::read('Captcha');
+
+		$this->set(compact('config'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function engine(): void {
+		$engines = $this->knownEngines();
+		$activeClass = (string)Configure::read('Captcha.engine', MathEngine::class);
+
+		$this->set(compact('engines', 'activeClass'));
+	}
+
+	/**
+	 * Renders one captcha through the configured engine for verification purposes.
+	 *
+	 * @return void
+	 */
+	public function preview(): void {
+		$activeClass = (string)Configure::read('Captcha.engine', MathEngine::class);
+		if (!class_exists($activeClass) || !is_subclass_of($activeClass, EngineInterface::class)) {
+			throw new BadRequestException(__d('captcha', 'Configured engine is not a valid EngineInterface.'));
+		}
+
+		/** @var \Captcha\Engine\EngineInterface $engine */
+		$engine = new $activeClass((array)Configure::read('Captcha.engineConfig'));
+		$payload = $engine->generate();
+
+		$image = $payload['image'] ?? null;
+		$imageDataUri = (is_string($image) && $image !== '')
+			? 'data:image/png;base64,' . base64_encode($image)
+			: null;
+
+		$this->set([
+			'engineClass' => $activeClass,
+			'engineShortName' => $this->shortName($activeClass),
+			'payload' => $payload,
+			'imageDataUri' => $imageDataUri,
+		]);
+	}
+
+	/**
+	 * @return \Cake\Http\Response|null
+	 */
+	public function cleanup() {
+		$this->request->allowMethod('post');
+
+		$count = $this->Captchas->cleanup(100);
+
+		$this->Flash->success(__d('captcha', '{0} captcha row(s) deleted.', $count));
+
+		return $this->redirect(['action' => 'index']);
+	}
+
+	/**
+	 * @return \Cake\Http\Response|null
+	 */
+	public function hardReset() {
+		$this->request->allowMethod('post');
+
+		$count = $this->Captchas->deleteAll([]);
+
+		$this->Flash->success(__d('captcha', '{0} captcha row(s) deleted.', $count));
+
+		return $this->redirect(['action' => 'index']);
+	}
+
+	/**
+	 * @param int $window Seconds to look back from now.
+	 *
+	 * @return array{open: int, solved: int, failed: int, expired: int}
+	 */
+	protected function aggregateCounts(int $window): array {
+		$since = DateTime::now()->subSeconds($window);
+		$rows = $this->Captchas->find()
+			->select([
+				'solved' => 'solved',
+				'used' => 'used',
+				'created' => 'created',
+			])
+			->where(['created >' => $since])
+			->disableHydration()
+			->all();
+
+		$open = 0;
+		$solved = 0;
+		$failed = 0;
+		$expired = 0;
+		$staleCutoff = DateTime::now()->subSeconds((int)(Configure::read('Captcha.maxTime') ?? DAY));
+		foreach ($rows as $row) {
+			$solvedValue = $row['solved'] ?? null;
+			if ($solvedValue === true || $solvedValue === 1) {
+				$solved++;
+
+				continue;
+			}
+			if ($solvedValue === false || $solvedValue === 0) {
+				$failed++;
+
+				continue;
+			}
+			if ($row['used'] === null) {
+				$rowCreated = $row['created'];
+				if ($rowCreated instanceof DateTime && $rowCreated < $staleCutoff) {
+					$expired++;
+				} else {
+					$open++;
+				}
+			}
+		}
+
+		return ['open' => $open, 'solved' => $solved, 'failed' => $failed, 'expired' => $expired];
+	}
+
+	/**
+	 * @return int
+	 */
+	protected function countThrottledIps(): int {
+		$rl = (array)Configure::read('Captcha.verifyRateLimit');
+		if (!($rl['enabled'] ?? true)) {
+			return 0;
+		}
+		$window = (int)($rl['window'] ?? 600);
+		$max = (int)($rl['maxFailures'] ?? 5);
+
+		$since = DateTime::now()->subSeconds($window);
+		$query = $this->Captchas->find();
+		$query->select([
+			'ip' => 'ip',
+			'failed_in_window' => $query->func()->count('*'),
+		])
+			->where(['solved' => false, 'created >' => $since])
+			->groupBy(['ip'])
+			->having(['failed_in_window >=' => $max]);
+
+		return $query->all()->count();
+	}
+
+	/**
+	 * Returns 7×24 grid: hours = 0..23, days = 0..6 (today back).
+	 *
+	 * @return array<int, array<int, array{issued: int, solved: int, failed: int}>>
+	 */
+	protected function buildHeatmap(): array {
+		$since = DateTime::now()->subSeconds(static::WINDOW_7D);
+		$rows = $this->Captchas->find()
+			->select(['created' => 'created', 'solved' => 'solved'])
+			->where(['created >' => $since])
+			->disableHydration()
+			->all();
+
+		$grid = [];
+		for ($d = 0; $d < 7; $d++) {
+			for ($h = 0; $h < 24; $h++) {
+				$grid[$d][$h] = ['issued' => 0, 'solved' => 0, 'failed' => 0];
+			}
+		}
+		$now = DateTime::now();
+		foreach ($rows as $row) {
+			$created = $row['created'];
+			if (!$created instanceof DateTime) {
+				continue;
+			}
+			$daysAgo = (int)$now->diffInDays($created, true);
+			if ($daysAgo < 0 || $daysAgo > 6) {
+				continue;
+			}
+			$hour = (int)$created->format('G');
+			$cell = $grid[$daysAgo][$hour];
+			$cell['issued']++;
+			$solvedValue = $row['solved'] ?? null;
+			if ($solvedValue === true || $solvedValue === 1) {
+				$cell['solved']++;
+			} elseif ($solvedValue === false || $solvedValue === 0) {
+				$cell['failed']++;
+			}
+			$grid[$daysAgo][$hour] = $cell;
+		}
+
+		return $grid;
+	}
+
+	/**
+	 * @return array{engine: string, maxPerUser: int, deadlockMinutes: int, cleanupProbability: int, rateLimit: string}
+	 */
+	protected function buildSnapshot(): array {
+		$engineClass = (string)Configure::read('Captcha.engine', MathEngine::class);
+		$rl = (array)Configure::read('Captcha.verifyRateLimit');
+		$rlSummary = ($rl['enabled'] ?? true)
+			? sprintf('%d/%ds', (int)($rl['maxFailures'] ?? 5), (int)($rl['window'] ?? 600))
+			: __d('captcha', 'disabled');
+
+		return [
+			'engine' => $this->shortName($engineClass),
+			'maxPerUser' => (int)(Configure::read('Captcha.maxPerUser') ?? 100),
+			'deadlockMinutes' => (int)(Configure::read('Captcha.deadlockMinutes') ?? 60),
+			'cleanupProbability' => (int)(Configure::read('Captcha.cleanupProbability') ?? 10),
+			'rateLimit' => $rlSummary,
+		];
+	}
+
+	/**
+	 * @return array<int, array{class: string, short: string}>
+	 */
+	protected function knownEngines(): array {
+		$candidates = [MathEngine::class, NullEngine::class];
+		$registered = (string)Configure::read('Captcha.engine', '');
+		if ($registered && !in_array($registered, $candidates, true)) {
+			$candidates[] = $registered;
+		}
+		$out = [];
+		foreach ($candidates as $candidate) {
+			if (App::className($candidate, 'Engine') || class_exists($candidate)) {
+				$out[] = ['class' => $candidate, 'short' => $this->shortName($candidate)];
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param string $class
+	 *
+	 * @return string
+	 */
+	protected function shortName(string $class): string {
+		$pos = strrpos($class, '\\');
+		if ($pos === false) {
+			return $class;
+		}
+
+		return substr($class, $pos + 1);
+	}
+
+}

--- a/src/Controller/Admin/IpsController.php
+++ b/src/Controller/Admin/IpsController.php
@@ -1,0 +1,206 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Controller\Admin;
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\I18n\DateTime;
+use Captcha\Cache\RateLimitKey;
+
+/**
+ * Per-IP signals and maintenance for the captcha admin backend.
+ *
+ * @property \Captcha\Model\Table\CaptchasTable $Captchas
+ */
+class IpsController extends CaptchaAdminAppController {
+
+	/**
+	 * @var string|null
+	 */
+	protected ?string $defaultTable = 'Captcha.Captchas';
+
+	/**
+     * @var int
+     */
+	protected const WINDOW_24H = 86400;
+
+	/**
+     * @var int
+     */
+	protected const WINDOW_7D = 604800;
+
+	/**
+	 * @return void
+	 */
+	public function index(): void {
+		$window = (int)$this->request->getQuery('window', static::WINDOW_24H);
+		if (!in_array($window, [static::WINDOW_24H, static::WINDOW_7D], true)) {
+			$window = static::WINDOW_24H;
+		}
+		$since = DateTime::now()->subSeconds($window);
+
+		$issued = $this->topIps($since, null);
+		$solved = $this->topIps($since, true);
+		$failed = $this->topIps($since, false);
+		$throttled = $this->throttledIps();
+
+		$this->set(compact('issued', 'solved', 'failed', 'throttled', 'window'));
+	}
+
+	/**
+	 * @param string|null $ip
+	 *
+	 * @return void
+	 */
+	public function view(?string $ip = null): void {
+		$ip = (string)$ip;
+		$query = $this->Captchas->find()
+			->where(['ip' => $ip])
+			->orderBy(['created' => 'DESC']);
+		$captchas = $this->paginate($query, ['limit' => 50]);
+
+		$since24h = DateTime::now()->subSeconds(static::WINDOW_24H);
+		$summary = ['issued' => 0, 'solved' => 0, 'failed' => 0];
+		$rows = $this->Captchas->find()
+			->select(['solved' => 'solved'])
+			->where(['ip' => $ip, 'created >' => $since24h])
+			->disableHydration()
+			->all();
+		foreach ($rows as $row) {
+			$summary['issued']++;
+			$solvedValue = $row['solved'] ?? null;
+			if ($solvedValue === true || $solvedValue === 1) {
+				$summary['solved']++;
+			} elseif ($solvedValue === false || $solvedValue === 0) {
+				$summary['failed']++;
+			}
+		}
+
+		$this->set(compact('ip', 'captchas', 'summary'));
+	}
+
+	/**
+	 * @param string|null $ip
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function reset(?string $ip = null) {
+		$this->request->allowMethod('post');
+		$ip = (string)$ip;
+
+		$count = $this->Captchas->reset($ip);
+
+		$this->Flash->success(__d('captcha', '{0} captcha row(s) deleted for IP {1}.', $count, $ip));
+
+		return $this->redirect(['action' => 'index']);
+	}
+
+	/**
+	 * @param string|null $ip
+	 *
+	 * @return \Cake\Http\Response|null
+	 */
+	public function clearRateLimit(?string $ip = null) {
+		$this->request->allowMethod('post');
+		$ip = (string)$ip;
+
+		$rl = (array)Configure::read('Captcha.verifyRateLimit');
+		$cache = (string)($rl['cache'] ?? 'default');
+		$scope = (string)($rl['scope'] ?? RateLimitKey::SCOPE_IP_SESSION);
+		$window = (int)($rl['window'] ?? 600);
+
+		$sessionIds = ['']; // covers ip-only scope
+		if ($scope === RateLimitKey::SCOPE_IP_SESSION) {
+			$since = DateTime::now()->subSeconds(max($window, static::WINDOW_24H));
+			$sessionIds = $this->Captchas->find()
+				->select(['session_id' => 'session_id'])
+				->where(['ip' => $ip, 'created >' => $since])
+				->distinct(['session_id'])
+				->disableHydration()
+				->all()
+				->extract('session_id')
+				->toList();
+			if (!$sessionIds) {
+				$sessionIds = [''];
+			}
+		}
+
+		$cleared = 0;
+		$now = time();
+		foreach ($sessionIds as $sessionId) {
+			$keyCurrent = RateLimitKey::build($ip, (string)$sessionId, $scope, $window, $now);
+			$keyPrev = RateLimitKey::build($ip, (string)$sessionId, $scope, $window, $now - $window);
+			foreach ([$keyCurrent, $keyPrev] as $key) {
+				if (Cache::delete($key, $cache)) {
+					$cleared++;
+				}
+			}
+		}
+
+		$this->Flash->success(__d('captcha', 'Cleared {0} rate-limit cache key(s) for IP {1}.', $cleared, $ip));
+
+		return $this->redirect(['action' => 'index']);
+	}
+
+	/**
+	 * @param \Cake\I18n\DateTime $since
+	 * @param bool|null $solved Filter on the solved column. `null` = no filter (all rows).
+	 *
+	 * @return array<int, array{ip: string, n: int}>
+	 */
+	protected function topIps(DateTime $since, ?bool $solved): array {
+		$query = $this->Captchas->find();
+		$conditions = ['created >' => $since];
+		if ($solved !== null) {
+			$conditions['solved'] = $solved;
+		}
+		$query->select([
+			'ip' => 'ip',
+			'n' => $query->func()->count('*'),
+		])
+			->where($conditions)
+			->groupBy(['ip'])
+			->orderBy(['n' => 'DESC'])
+			->limit(10);
+
+		$out = [];
+		foreach ($query->disableHydration()->all() as $row) {
+			$out[] = ['ip' => (string)$row['ip'], 'n' => (int)$row['n']];
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @return array<int, array{ip: string, n: int}>
+	 */
+	protected function throttledIps(): array {
+		$rl = (array)Configure::read('Captcha.verifyRateLimit');
+		if (!($rl['enabled'] ?? true)) {
+			return [];
+		}
+		$window = (int)($rl['window'] ?? 600);
+		$max = (int)($rl['maxFailures'] ?? 5);
+
+		$since = DateTime::now()->subSeconds($window);
+		$query = $this->Captchas->find();
+		$query->select([
+			'ip' => 'ip',
+			'n' => $query->func()->count('*'),
+		])
+			->where(['solved' => false, 'created >' => $since])
+			->groupBy(['ip'])
+			->having(['n >=' => $max])
+			->orderBy(['n' => 'DESC'])
+			->limit(10);
+
+		$out = [];
+		foreach ($query->disableHydration()->all() as $row) {
+			$out[] = ['ip' => (string)$row['ip'], 'n' => (int)$row['n']];
+		}
+
+		return $out;
+	}
+
+}

--- a/src/Model/Behavior/CaptchaBehavior.php
+++ b/src/Model/Behavior/CaptchaBehavior.php
@@ -13,6 +13,7 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Routing\Router;
 use Cake\Validation\Validator;
+use Captcha\Cache\RateLimitKey;
 use Captcha\Engine\EngineInterface;
 use Captcha\Engine\MathEngine;
 use Captcha\Engine\NullEngine;
@@ -237,6 +238,7 @@ class CaptchaBehavior extends Behavior {
 		}
 
 		$isValid = hash_equals((string)$captcha->result, (string)$value);
+		$captcha->solved = $isValid;
 		if (!$this->_captchasTable->markUsed($captcha)) {
 			return false;
 		}
@@ -416,16 +418,7 @@ class CaptchaBehavior extends Behavior {
 		$config = $this->_getVerifyRateLimitConfig();
 		['sessionId' => $sessionId, 'ip' => $ip] = $this->_getRequestIdentity();
 
-		$scope = $config['scope'];
-		if ($scope === 'ip') {
-			$keyData = $ip;
-		} else {
-			$keyData = $ip . '|' . $sessionId;
-		}
-		$window = max((int)$config['window'], 1);
-		$bucket = (int)floor(time() / $window);
-
-		return 'captcha_verify_rate_limit_' . sha1($keyData) . '_' . $bucket;
+		return RateLimitKey::build($ip, $sessionId, (string)$config['scope'], (int)$config['window']);
 	}
 
 	/**

--- a/src/Model/Entity/Captcha.php
+++ b/src/Model/Entity/Captcha.php
@@ -15,6 +15,7 @@ use Cake\ORM\Entity;
  * @property string $image
  * @property \Cake\I18n\DateTime $created
  * @property \Cake\I18n\DateTime|null $used
+ * @property bool|null $solved
  */
 class Captcha extends Entity {
 

--- a/src/Model/Table/CaptchasTable.php
+++ b/src/Model/Table/CaptchasTable.php
@@ -71,6 +71,10 @@ class CaptchasTable extends Table {
 			->dateTime('used')
 			->allowEmptyDateTime('used');
 
+		$validator
+			->boolean('solved')
+			->allowEmptyString('solved');
+
 		return $validator;
 	}
 

--- a/templates/Admin/Captcha/config.php
+++ b/templates/Admin/Captcha/config.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array $config
+ */
+
+$this->assign('title', __d('captcha', 'Captcha · Config'));
+
+$flatten = function (array $config, string $prefix = '') use (&$flatten): array {
+	$out = [];
+	foreach ($config as $key => $value) {
+		$compoundKey = $prefix === '' ? (string)$key : $prefix . '.' . (string)$key;
+		if (is_array($value)) {
+			$out = array_merge($out, $flatten($value, $compoundKey));
+
+			continue;
+		}
+		$out[$compoundKey] = $value;
+	}
+
+	return $out;
+};
+
+$flat = $flatten($config);
+ksort($flat);
+?>
+
+<div class="card">
+	<div class="card-header"><?= __d('captcha', 'Resolved Captcha.* configuration') ?></div>
+	<div class="card-body">
+		<?php if (!$flat) { ?>
+			<p class="text-muted mb-0"><?= __d('captcha', 'No configuration loaded.') ?></p>
+		<?php } else { ?>
+			<table class="table table-sm config-table mb-0">
+				<thead>
+					<tr>
+						<th><?= __d('captcha', 'Key') ?></th>
+						<th><?= __d('captcha', 'Value') ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ($flat as $key => $value) { ?>
+						<tr>
+							<td><?= h('Captcha.' . $key) ?></td>
+							<td>
+								<?php if ($value instanceof Closure) { ?>
+									<em class="text-muted"><?= __d('captcha', 'Closure') ?></em>
+								<?php } elseif (is_bool($value)) { ?>
+									<?= $value ? 'true' : 'false' ?>
+								<?php } else { ?>
+									<?= h((string)$value) ?>
+								<?php } ?>
+							</td>
+						</tr>
+					<?php } ?>
+				</tbody>
+			</table>
+		<?php } ?>
+	</div>
+</div>

--- a/templates/Admin/Captcha/engine.php
+++ b/templates/Admin/Captcha/engine.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<int, array{class: string, short: string}> $engines
+ * @var string $activeClass
+ */
+
+$this->assign('title', __d('captcha', 'Captcha · Engine'));
+?>
+
+<div class="card">
+	<div class="card-header"><?= __d('captcha', 'Available engines') ?></div>
+	<div class="card-body">
+		<table class="table mb-0">
+			<thead>
+				<tr>
+					<th><?= __d('captcha', 'Engine') ?></th>
+					<th><?= __d('captcha', 'Class') ?></th>
+					<th class="text-end"><?= __d('captcha', 'Active') ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($engines as $engine) { ?>
+					<tr>
+						<td><?= h($engine['short']) ?></td>
+						<td class="font-monospace small text-muted"><?= h($engine['class']) ?></td>
+						<td class="text-end">
+							<?php if ($engine['class'] === $activeClass) { ?>
+								<span class="badge text-bg-success"><?= __d('captcha', 'active') ?></span>
+							<?php } ?>
+						</td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/templates/Admin/Captcha/index.php
+++ b/templates/Admin/Captcha/index.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array{open: int, solved: int, failed: int, expired: int} $tiles24h
+ * @var array{open: int, solved: int, failed: int, expired: int} $tiles7d
+ * @var int $throttledIps
+ * @var array<int, array<int, array{issued: int, solved: int, failed: int}>> $heatmap
+ * @var array{engine: string, maxPerUser: int, deadlockMinutes: int, cleanupProbability: int, rateLimit: string} $snapshot
+ */
+
+$this->assign('title', __d('captcha', 'Captcha · Dashboard'));
+
+$attempted = $tiles24h['solved'] + $tiles24h['failed'];
+$solveRate = $attempted > 0 ? round(($tiles24h['solved'] / $attempted) * 100) : null;
+?>
+
+<div class="captcha-snapshot">
+	<span class="badge text-bg-secondary"><?= __d('captcha', 'Engine') ?>: <?= h($snapshot['engine']) ?></span>
+	<span class="badge text-bg-secondary"><?= __d('captcha', 'maxPerUser') ?>: <?= $snapshot['maxPerUser'] ?></span>
+	<span class="badge text-bg-secondary"><?= __d('captcha', 'deadlockMinutes') ?>: <?= $snapshot['deadlockMinutes'] ?></span>
+	<span class="badge text-bg-secondary"><?= __d('captcha', 'cleanupProbability') ?>: <?= $snapshot['cleanupProbability'] ?>%</span>
+	<span class="badge text-bg-secondary"><?= __d('captcha', 'rate-limit') ?>: <?= h($snapshot['rateLimit']) ?></span>
+</div>
+
+<div class="row g-3 mb-4">
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Open'), 'value' => $tiles24h['open'], 'note' => __d('captcha', 'last 24h'), 'flavor' => 'default']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Solved (24h)'), 'value' => $tiles24h['solved'], 'note' => __d('captcha', '7d: {0}', $tiles7d['solved']), 'flavor' => 'success']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Failed (24h)'), 'value' => $tiles24h['failed'], 'note' => __d('captcha', '7d: {0}', $tiles7d['failed']), 'flavor' => 'danger']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Solve rate'), 'value' => $solveRate === null ? '—' : ($solveRate . '%'), 'note' => __d('captcha', 'last 24h'), 'flavor' => 'success']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Expired (no attempt)'), 'value' => $tiles24h['expired'], 'note' => __d('captcha', 'last 24h'), 'flavor' => 'warning']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Throttled now'), 'value' => $throttledIps, 'note' => __d('captcha', 'IPs over the threshold'), 'flavor' => 'warning']) ?>
+</div>
+
+<div class="card mb-4">
+	<div class="card-header"><?= __d('captcha', 'Issued per hour, last 7 days') ?></div>
+	<div class="card-body">
+		<?= $this->element('Captcha.Admin/heatmap', ['heatmap' => $heatmap]) ?>
+	</div>
+</div>
+
+<div class="card">
+	<div class="card-header"><?= __d('captcha', 'Maintenance') ?></div>
+	<div class="card-body d-flex gap-2 flex-wrap">
+		<?= $this->Form->postLink(
+			'<i class="fas fa-broom me-1"></i>' . __d('captcha', 'Run cleanup now'),
+			['action' => 'cleanup'],
+			[
+				'class' => 'btn btn-outline-primary btn-sm',
+				'escapeTitle' => false,
+				'confirm' => __d('captcha', 'Delete all captchas older than maxTime?'),
+				'block' => true,
+			],
+		) ?>
+		<?= $this->Form->postLink(
+			'<i class="fas fa-trash me-1"></i>' . __d('captcha', 'Hard reset (truncate)'),
+			['action' => 'hardReset'],
+			[
+				'class' => 'btn btn-outline-danger btn-sm',
+				'escapeTitle' => false,
+				'confirm' => __d('captcha', 'Delete ALL captcha rows? This cannot be undone.'),
+				'block' => true,
+			],
+		) ?>
+	</div>
+</div>

--- a/templates/Admin/Captcha/preview.php
+++ b/templates/Admin/Captcha/preview.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var string $engineClass
+ * @var string $engineShortName
+ * @var array $payload
+ * @var string|null $imageDataUri
+ */
+
+$this->assign('title', __d('captcha', 'Captcha · Preview'));
+?>
+
+<div class="card">
+	<div class="card-header d-flex justify-content-between align-items-center">
+		<span><?= __d('captcha', 'Engine: {0}', h($engineShortName)) ?></span>
+		<?= $this->Html->link(
+			'<i class="fas fa-arrows-rotate me-1"></i>' . __d('captcha', 'Regenerate'),
+			['action' => 'preview'],
+			['class' => 'btn btn-sm btn-outline-primary', 'escapeTitle' => false],
+		) ?>
+	</div>
+	<div class="card-body">
+		<?php if ($imageDataUri) { ?>
+			<div class="mb-3">
+				<img src="<?= h($imageDataUri) ?>" alt="<?= __d('captcha', 'Sample captcha') ?>" class="border rounded p-2 bg-white"/>
+			</div>
+		<?php } ?>
+		<dl class="row mb-0">
+			<dt class="col-sm-3"><?= __d('captcha', 'Class') ?></dt>
+			<dd class="col-sm-9 font-monospace small"><?= h($engineClass) ?></dd>
+
+			<?php foreach ($payload as $key => $value) {
+				if ($key === 'image') {
+					continue;
+				}
+				?>
+				<dt class="col-sm-3"><?= h((string)$key) ?></dt>
+				<dd class="col-sm-9">
+					<?php if (is_array($value) || $value instanceof Closure) { ?>
+						<em class="text-muted"><?= __d('captcha', '(non-scalar)') ?></em>
+					<?php } else { ?>
+						<?= h((string)$value) ?>
+					<?php } ?>
+				</dd>
+			<?php } ?>
+		</dl>
+	</div>
+</div>

--- a/templates/Admin/Ips/index.php
+++ b/templates/Admin/Ips/index.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<int, array{ip: string, n: int}> $issued
+ * @var array<int, array{ip: string, n: int}> $solved
+ * @var array<int, array{ip: string, n: int}> $failed
+ * @var array<int, array{ip: string, n: int}> $throttled
+ * @var int $window
+ */
+
+$this->assign('title', __d('captcha', 'Captcha · IPs'));
+$dayLabel = $window === 604800 ? __d('captcha', '7 days') : __d('captcha', '24 hours');
+
+$boards = [
+	['title' => __d('captcha', 'Issued'), 'rows' => $issued, 'flavor' => 'primary'],
+	['title' => __d('captcha', 'Solved'), 'rows' => $solved, 'flavor' => 'success'],
+	['title' => __d('captcha', 'Failed'), 'rows' => $failed, 'flavor' => 'danger'],
+	['title' => __d('captcha', 'Currently rate-limited'), 'rows' => $throttled, 'flavor' => 'warning', 'tooltip' => __d('captcha', 'Derived from captcha rows; matches behavior config in the common path.')],
+];
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+	<h2 class="mb-0"><?= __d('captcha', 'Top IPs') ?></h2>
+	<div class="btn-group btn-group-sm" role="group">
+		<?= $this->Html->link(
+			__d('captcha', '24h'),
+			['action' => 'index', '?' => ['window' => 86400]],
+			['class' => 'btn btn-' . ($window === 86400 ? 'primary' : 'outline-primary')],
+		) ?>
+		<?= $this->Html->link(
+			__d('captcha', '7d'),
+			['action' => 'index', '?' => ['window' => 604800]],
+			['class' => 'btn btn-' . ($window === 604800 ? 'primary' : 'outline-primary')],
+		) ?>
+	</div>
+</div>
+
+<div class="row g-3">
+	<?php foreach ($boards as $board) { ?>
+		<div class="col-md-6">
+			<div class="card">
+				<div class="card-header bg-<?= h($board['flavor']) ?> text-white d-flex justify-content-between align-items-center">
+					<span><?= h($board['title']) ?></span>
+					<?php if (isset($board['tooltip'])) { ?>
+						<i class="fas fa-circle-info" title="<?= h($board['tooltip']) ?>"></i>
+					<?php } else { ?>
+						<small class="opacity-75"><?= h($dayLabel) ?></small>
+					<?php } ?>
+				</div>
+				<div class="card-body p-0">
+					<?php if (!$board['rows']) { ?>
+						<p class="text-muted small p-3 mb-0"><?= __d('captcha', 'No IPs in this category.') ?></p>
+					<?php } else { ?>
+						<table class="table table-sm mb-0">
+							<tbody>
+								<?php foreach ($board['rows'] as $row) {
+									echo $this->element('Captcha.Admin/ip_row', ['ip' => $row['ip'], 'n' => $row['n']]);
+								} ?>
+							</tbody>
+						</table>
+					<?php } ?>
+				</div>
+			</div>
+		</div>
+	<?php } ?>
+</div>

--- a/templates/Admin/Ips/view.php
+++ b/templates/Admin/Ips/view.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var string $ip
+ * @var iterable<\Captcha\Model\Entity\Captcha> $captchas
+ * @var array{issued: int, solved: int, failed: int} $summary
+ */
+
+$this->assign('title', __d('captcha', 'Captcha · IP {0}', $ip));
+?>
+
+<nav aria-label="breadcrumb">
+	<ol class="breadcrumb">
+		<li class="breadcrumb-item"><?= $this->Html->link(__d('captcha', 'IPs'), ['action' => 'index']) ?></li>
+		<li class="breadcrumb-item active font-monospace"><?= h($ip) ?></li>
+	</ol>
+</nav>
+
+<div class="row g-3 mb-4">
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Issued (24h)'), 'value' => $summary['issued'], 'note' => h($ip), 'flavor' => 'default']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Solved (24h)'), 'value' => $summary['solved'], 'note' => h($ip), 'flavor' => 'success']) ?>
+	<?= $this->element('Captcha.Admin/stat_tile', ['label' => __d('captcha', 'Failed (24h)'), 'value' => $summary['failed'], 'note' => h($ip), 'flavor' => 'danger']) ?>
+</div>
+
+<div class="card mb-4">
+	<div class="card-header d-flex justify-content-between align-items-center">
+		<span><?= __d('captcha', 'Recent captchas for {0}', h($ip)) ?></span>
+		<div class="btn-group btn-group-sm">
+			<?= $this->Form->postLink(
+				'<i class="fas fa-bolt me-1"></i>' . __d('captcha', 'Unblock'),
+				['action' => 'clearRateLimit', $ip],
+				[
+					'class' => 'btn btn-outline-warning',
+					'escapeTitle' => false,
+					'confirm' => __d('captcha', 'Clear rate-limit cache for {0}?', $ip),
+					'block' => true,
+				],
+			) ?>
+			<?= $this->Form->postLink(
+				'<i class="fas fa-trash me-1"></i>' . __d('captcha', 'Reset'),
+				['action' => 'reset', $ip],
+				[
+					'class' => 'btn btn-outline-danger',
+					'escapeTitle' => false,
+					'confirm' => __d('captcha', 'Delete all captcha rows for {0}?', $ip),
+					'block' => true,
+				],
+			) ?>
+		</div>
+	</div>
+	<div class="card-body p-0">
+		<?php
+		$rows = is_array($captchas) ? $captchas : iterator_to_array($captchas);
+		?>
+		<?php if (!$rows) { ?>
+			<p class="text-muted p-3 mb-0"><?= __d('captcha', 'No captchas seen for this IP.') ?></p>
+		<?php } else { ?>
+			<table class="table table-sm mb-0">
+				<thead>
+					<tr>
+						<th><?= __d('captcha', 'Created') ?></th>
+						<th><?= __d('captcha', 'Used') ?></th>
+						<th class="text-center"><?= __d('captcha', 'Solved') ?></th>
+						<th><?= __d('captcha', 'Session') ?></th>
+						<th><?= __d('captcha', 'UUID') ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ($rows as $captcha) {
+						$solved = $captcha->solved;
+						$icon = $solved === true ? '<i class="fas fa-check solved-icon-true"></i>' : ($solved === false ? '<i class="fas fa-xmark solved-icon-false"></i>' : '<i class="fas fa-minus solved-icon-null"></i>');
+						?>
+						<tr>
+							<td class="small"><?= h((string)$captcha->created) ?></td>
+							<td class="small"><?= $captcha->used ? h((string)$captcha->used) : '<span class="text-muted">—</span>' ?></td>
+							<td class="text-center"><?= $icon ?></td>
+							<td class="font-monospace small text-muted"><?= h(substr((string)$captcha->session_id, 0, 12)) ?>…</td>
+							<td class="font-monospace small text-muted"><?= h(substr((string)$captcha->uuid, 0, 8)) ?>…</td>
+						</tr>
+					<?php } ?>
+				</tbody>
+			</table>
+		<?php } ?>
+	</div>
+</div>
+
+<?php if ($this->Paginator->hasPage(2)) { ?>
+	<nav><?= $this->Paginator->numbers() ?></nav>
+<?php } ?>

--- a/templates/element/Admin/heatmap.php
+++ b/templates/element/Admin/heatmap.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var array<int, array<int, array{issued: int, solved: int, failed: int}>> $heatmap
+ */
+
+$max = 0;
+foreach ($heatmap as $row) {
+	foreach ($row as $cell) {
+		if ($cell['issued'] > $max) {
+			$max = $cell['issued'];
+		}
+	}
+}
+
+$bin = function (int $issued) use ($max): int {
+	if ($issued <= 0 || $max <= 0) {
+		return 0;
+	}
+	$ratio = $issued / $max;
+	if ($ratio > 0.75) {
+		return 4;
+	}
+	if ($ratio > 0.5) {
+		return 3;
+	}
+	if ($ratio > 0.25) {
+		return 2;
+	}
+
+	return 1;
+};
+?>
+<div class="heatmap">
+	<div class="col-label"></div>
+	<?php for ($h = 0; $h < 24; $h++) { ?>
+		<div class="col-label"><?= $h ?></div>
+	<?php } ?>
+	<?php for ($d = 0; $d < 7; $d++) { ?>
+		<div class="day-label"><?= $d === 0 ? __d('captcha', 'today') : __d('captcha', '-{0}d', $d) ?></div>
+		<?php for ($h = 0; $h < 24; $h++) {
+			$cell = $heatmap[$d][$h];
+			$tooltip = sprintf(
+				'%d issued · %d solved · %d failed',
+				$cell['issued'],
+				$cell['solved'],
+				$cell['failed'],
+			);
+			?>
+			<div class="heatmap-cell" data-bin="<?= $bin($cell['issued']) ?>" title="<?= h($tooltip) ?>"></div>
+		<?php } ?>
+	<?php } ?>
+</div>

--- a/templates/element/Admin/ip_row.php
+++ b/templates/element/Admin/ip_row.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var string $ip
+ * @var int $n
+ */
+?>
+<tr>
+	<td class="font-monospace">
+		<?= $this->Html->link(h($ip), ['action' => 'view', $ip], ['escapeTitle' => false]) ?>
+	</td>
+	<td class="text-end"><span class="badge text-bg-secondary"><?= h((string)$n) ?></span></td>
+	<td class="text-end" style="width: 14rem;">
+		<?= $this->Form->postLink(
+			'<i class="fas fa-bolt"></i> ' . __d('captcha', 'Unblock'),
+			['action' => 'clearRateLimit', $ip],
+			[
+				'class' => 'btn btn-sm btn-outline-warning',
+				'escapeTitle' => false,
+				'confirm' => __d('captcha', 'Clear rate-limit cache for {0}?', $ip),
+				'block' => true,
+			],
+		) ?>
+		<?= $this->Form->postLink(
+			'<i class="fas fa-trash"></i>',
+			['action' => 'reset', $ip],
+			[
+				'class' => 'btn btn-sm btn-outline-danger',
+				'escapeTitle' => false,
+				'confirm' => __d('captcha', 'Delete all captcha rows for {0}?', $ip),
+				'block' => true,
+				'title' => __d('captcha', 'Delete all rows for this IP'),
+			],
+		) ?>
+	</td>
+</tr>

--- a/templates/element/Admin/nav.php
+++ b/templates/element/Admin/nav.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+$current = $this->request->getParam('controller');
+$action = $this->request->getParam('action');
+
+$links = [
+	['label' => __d('captcha', 'Dashboard'), 'url' => ['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index'], 'active' => $current === 'Captcha' && $action === 'index'],
+	['label' => __d('captcha', 'IPs'), 'url' => ['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'index'], 'active' => $current === 'Ips'],
+	['label' => __d('captcha', 'Engine'), 'url' => ['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'engine'], 'active' => $current === 'Captcha' && $action === 'engine'],
+	['label' => __d('captcha', 'Preview'), 'url' => ['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'preview'], 'active' => $current === 'Captcha' && $action === 'preview'],
+	['label' => __d('captcha', 'Config'), 'url' => ['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'config'], 'active' => $current === 'Captcha' && $action === 'config'],
+];
+?>
+<ul class="navbar-nav ms-auto">
+	<?php foreach ($links as $link) { ?>
+		<li class="nav-item">
+			<?= $this->Html->link($link['label'], $link['url'], ['class' => 'nav-link' . ($link['active'] ? ' active' : '')]) ?>
+		</li>
+	<?php } ?>
+</ul>

--- a/templates/element/Admin/stat_tile.php
+++ b/templates/element/Admin/stat_tile.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var string $label
+ * @var int|string $value
+ * @var string $note
+ * @var string $flavor
+ */
+?>
+<div class="col-sm-6 col-lg-4 col-xl-2">
+	<div class="card stat-tile <?= h($flavor) ?>">
+		<div class="card-body">
+			<span class="label"><?= h($label) ?></span>
+			<h2><?= h((string)$value) ?></h2>
+			<span class="delta"><?= h($note) ?></span>
+		</div>
+	</div>
+</div>

--- a/templates/layout/captcha-admin.php
+++ b/templates/layout/captcha-admin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Captcha admin backend layout.
+ *
+ * @var \App\View\AppView $this
+ */
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
+	<title><?= $this->fetch('title') ?: __d('captcha', 'Captcha Admin') ?></title>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css">
+	<style>
+		body { background: #f5f7fa; }
+		.captcha-admin-nav { background: #1f2937; }
+		.captcha-admin-nav .navbar-brand,
+		.captcha-admin-nav .nav-link { color: #f9fafb; }
+		.captcha-admin-nav .nav-link:hover { color: #93c5fd; }
+		.captcha-admin-nav .nav-link.active { color: #fbbf24; }
+		.stat-tile { border-left: 4px solid #3b82f6; }
+		.stat-tile.success { border-left-color: #16a34a; }
+		.stat-tile.warning { border-left-color: #f59e0b; }
+		.stat-tile.danger { border-left-color: #dc2626; }
+		.stat-tile h2 { font-size: 1.85rem; margin: 0; }
+		.stat-tile .label { color: #6b7280; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
+		.stat-tile .delta { color: #6b7280; font-size: 0.8rem; }
+		.heatmap { display: grid; grid-template-columns: 4rem repeat(24, 1fr); gap: 2px; font-size: 0.75rem; }
+		.heatmap .day-label { color: #6b7280; padding-right: 0.5rem; text-align: right; align-self: center; }
+		.heatmap .col-label { color: #9ca3af; text-align: center; align-self: end; padding-bottom: 0.25rem; }
+		.heatmap-cell { aspect-ratio: 1; border-radius: 2px; background: #e5e7eb; }
+		.heatmap-cell[data-bin="1"] { background: #bfdbfe; }
+		.heatmap-cell[data-bin="2"] { background: #60a5fa; }
+		.heatmap-cell[data-bin="3"] { background: #2563eb; }
+		.heatmap-cell[data-bin="4"] { background: #1e3a8a; }
+		.config-table tbody td { font-family: ui-monospace, monospace; font-size: 0.85rem; }
+		.captcha-snapshot { background: #fff; border: 1px solid #e5e7eb; border-radius: 0.375rem; padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 0.9rem; }
+		.captcha-snapshot .badge { margin-right: 0.5rem; }
+		.solved-icon-true { color: #16a34a; }
+		.solved-icon-false { color: #dc2626; }
+		.solved-icon-null { color: #9ca3af; }
+	</style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg captcha-admin-nav">
+	<div class="container-fluid">
+		<a class="navbar-brand" href="<?= $this->Url->build(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']) ?>">
+			<i class="fas fa-shield-halved me-2"></i><?= __d('captcha', 'Captcha') ?>
+		</a>
+		<?= $this->element('Captcha.Admin/nav') ?>
+	</div>
+</nav>
+
+<div class="container-fluid py-4">
+	<?= $this->Flash->render() ?>
+	<?= $this->fetch('content') ?>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/tests/Fixture/CaptchasFixture.php
+++ b/tests/Fixture/CaptchasFixture.php
@@ -24,9 +24,13 @@ class CaptchasFixture extends TestFixture {
 		'result' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
 		'created' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
 		'used' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+		'solved' => ['type' => 'boolean', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
 		'_constraints' => [
 			'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
 			'uuid' => ['type' => 'unique', 'columns' => ['uuid'], 'length' => []],
+		],
+		'_indexes' => [
+			'idx_solved_created' => ['type' => 'index', 'columns' => ['solved', 'created'], 'length' => []],
 		],
 		'_options' => [
 			'engine' => 'InnoDB',

--- a/tests/TestCase/Cache/RateLimitKeyTest.php
+++ b/tests/TestCase/Cache/RateLimitKeyTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Test\TestCase\Cache;
+
+use Cake\TestSuite\TestCase;
+use Captcha\Cache\RateLimitKey;
+
+class RateLimitKeyTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testIpScopeIgnoresSession() {
+		$now = 1000;
+		$keyOne = RateLimitKey::build('1.2.3.4', 'sessA', RateLimitKey::SCOPE_IP, 600, $now);
+		$keyTwo = RateLimitKey::build('1.2.3.4', 'sessB', RateLimitKey::SCOPE_IP, 600, $now);
+
+		$this->assertSame($keyOne, $keyTwo);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIpSessionScopeIncludesSession() {
+		$now = 1000;
+		$keyOne = RateLimitKey::build('1.2.3.4', 'sessA', RateLimitKey::SCOPE_IP_SESSION, 600, $now);
+		$keyTwo = RateLimitKey::build('1.2.3.4', 'sessB', RateLimitKey::SCOPE_IP_SESSION, 600, $now);
+
+		$this->assertNotSame($keyOne, $keyTwo);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testBucketRollsOver() {
+		$keyBefore = RateLimitKey::build('1.2.3.4', 'sess', RateLimitKey::SCOPE_IP_SESSION, 600, 599);
+		$keyAfter = RateLimitKey::build('1.2.3.4', 'sess', RateLimitKey::SCOPE_IP_SESSION, 600, 600);
+
+		$this->assertNotSame($keyBefore, $keyAfter);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testKeyShape() {
+		$key = RateLimitKey::build('1.2.3.4', 'sess', RateLimitKey::SCOPE_IP_SESSION, 600, 1000);
+
+		$this->assertStringStartsWith(RateLimitKey::KEY_PREFIX, $key);
+		$this->assertStringEndsWith('_1', $key);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testZeroWindowGetsClampedToOne() {
+		$keyOne = RateLimitKey::build('1.2.3.4', 'sess', RateLimitKey::SCOPE_IP_SESSION, 0, 5);
+		$keyTwo = RateLimitKey::build('1.2.3.4', 'sess', RateLimitKey::SCOPE_IP_SESSION, 1, 5);
+
+		$this->assertSame($keyTwo, $keyOne);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDifferentIpsProduceDifferentKeys() {
+		$now = 1000;
+		$keyOne = RateLimitKey::build('1.2.3.4', 'sess', RateLimitKey::SCOPE_IP_SESSION, 600, $now);
+		$keyTwo = RateLimitKey::build('5.6.7.8', 'sess', RateLimitKey::SCOPE_IP_SESSION, 600, $now);
+
+		$this->assertNotSame($keyOne, $keyTwo);
+	}
+
+}

--- a/tests/TestCase/Controller/Admin/CaptchaControllerTest.php
+++ b/tests/TestCase/Controller/Admin/CaptchaControllerTest.php
@@ -1,0 +1,169 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Test\TestCase\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\Exception\MethodNotAllowedException;
+use Cake\Http\ServerRequest;
+use Cake\I18n\DateTime;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @uses \Captcha\Controller\Admin\CaptchaController
+ */
+class CaptchaControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Captcha.Captchas',
+		'core.Sessions',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('Captcha', []);
+		$this->loadPlugins(['Captcha']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexDeniedByDefault() {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(ForbiddenException::class);
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexAllowedWithClosure() {
+		Configure::write('Captcha.adminAccess', fn (ServerRequest $request): bool => true);
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Captcha');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexClosureMayDeny() {
+		Configure::write('Captcha.adminAccess', fn (ServerRequest $request): bool => false);
+
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(ForbiddenException::class);
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testConfig() {
+		Configure::write('Captcha', ['adminAccess' => fn (): bool => true, 'maxPerUser' => 42]);
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'config']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Captcha.maxPerUser');
+		$this->assertResponseContains('42');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testEngine() {
+		Configure::write('Captcha.adminAccess', fn (): bool => true);
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'engine']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('MathEngine');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCleanupRunsAndFlashes() {
+		Configure::write('Captcha.adminAccess', fn (): bool => true);
+		$this->enableRetainFlashMessages();
+
+		$this->post(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'cleanup']);
+
+		$this->assertRedirect(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']);
+		$this->assertFlashMessage(__d('captcha', '{0} captcha row(s) deleted.', 1));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testHardResetTruncates() {
+		Configure::write('Captcha.adminAccess', fn (): bool => true);
+		$this->enableRetainFlashMessages();
+
+		$this->post(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'hardReset']);
+
+		$this->assertRedirect(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']);
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		$this->assertSame(0, $Captchas->find()->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCleanupRequiresPost() {
+		Configure::write('Captcha.adminAccess', fn (): bool => true);
+
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(MethodNotAllowedException::class);
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'cleanup']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexCountsCorrectly() {
+		Configure::write('Captcha.adminAccess', fn (): bool => true);
+
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		// Solved
+		$row = $Captchas->newEntity([
+			'uuid' => '22222222-2222-4222-8222-222222222222',
+			'session_id' => 's',
+			'ip' => '1.1.1.1',
+			'result' => '1',
+			'used' => new DateTime('-30 minutes'),
+			'solved' => true,
+		]);
+		$Captchas->saveOrFail($row);
+		// Failed
+		$row = $Captchas->newEntity([
+			'uuid' => '33333333-3333-4333-8333-333333333333',
+			'session_id' => 's',
+			'ip' => '2.2.2.2',
+			'result' => '1',
+			'used' => new DateTime('-30 minutes'),
+			'solved' => false,
+		]);
+		$Captchas->saveOrFail($row);
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Captcha', 'action' => 'index']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('Solved');
+		$this->assertResponseContains('Failed');
+	}
+
+}

--- a/tests/TestCase/Controller/Admin/IpsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/IpsControllerTest.php
@@ -1,0 +1,194 @@
+<?php
+declare(strict_types=1);
+
+namespace Captcha\Test\TestCase\Controller\Admin;
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\I18n\DateTime;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use Captcha\Cache\RateLimitKey;
+
+/**
+ * @uses \Captcha\Controller\Admin\IpsController
+ */
+class IpsControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.Captcha.Captchas',
+		'core.Sessions',
+	];
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Configure::write('Captcha', ['adminAccess' => fn (): bool => true]);
+		Cache::drop('captcha_admin_test');
+		Cache::setConfig('captcha_admin_test', ['className' => 'Array']);
+		$this->loadPlugins(['Captcha']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		Cache::clear('captcha_admin_test');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexShowsLeaderboards() {
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		foreach (['1.1.1.1', '2.2.2.2', '3.3.3.3'] as $i => $ip) {
+			$row = $Captchas->newEntity([
+				'uuid' => sprintf('11111111-1111-4111-8111-%012d', $i + 100),
+				'session_id' => 's',
+				'ip' => $ip,
+				'result' => '1',
+				'solved' => $i === 0 ? true : ($i === 1 ? false : null),
+				'used' => $i < 2 ? new DateTime('-10 minutes') : null,
+			]);
+			$Captchas->saveOrFail($row);
+		}
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'index']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('1.1.1.1');
+		$this->assertResponseContains('2.2.2.2');
+		$this->assertResponseContains('3.3.3.3');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testIndexShowsThrottledIp() {
+		Configure::write('Captcha.verifyRateLimit', [
+			'enabled' => true,
+			'maxFailures' => 2,
+			'window' => 600,
+			'scope' => 'ip_session',
+			'cache' => 'captcha_admin_test',
+		]);
+
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		for ($i = 0; $i < 3; $i++) {
+			$row = $Captchas->newEntity([
+				'uuid' => sprintf('11111111-1111-4111-8111-%012d', $i + 200),
+				'session_id' => 's',
+				'ip' => '9.9.9.9',
+				'result' => '1',
+				'solved' => false,
+				'used' => new DateTime('-1 minute'),
+			]);
+			$Captchas->saveOrFail($row);
+		}
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'index']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('9.9.9.9');
+		$this->assertResponseContains('rate-limited');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testViewShowsRowsForIp() {
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		$row = $Captchas->newEntity([
+			'uuid' => '44444444-4444-4444-8444-444444444444',
+			'session_id' => 'sessabc',
+			'ip' => '4.4.4.4',
+			'result' => '1',
+			'solved' => true,
+			'used' => new DateTime('-20 minutes'),
+		]);
+		$Captchas->saveOrFail($row);
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'view', '4.4.4.4']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains('4.4.4.4');
+		$this->assertResponseContains('44444444');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testViewUnknownIpShowsEmptyState() {
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'view', '0.0.0.0']);
+
+		$this->assertResponseOk();
+		$this->assertResponseContains(__d('captcha', 'No captchas seen for this IP.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testResetDeletesIpRows() {
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		foreach (['5.5.5.5', '5.5.5.5', '6.6.6.6'] as $i => $ip) {
+			$row = $Captchas->newEntity([
+				'uuid' => sprintf('55555555-5555-4555-8555-%012d', $i + 300),
+				'session_id' => 's',
+				'ip' => $ip,
+				'result' => '1',
+			]);
+			$Captchas->saveOrFail($row);
+		}
+		$this->enableRetainFlashMessages();
+
+		$this->post(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'reset', '5.5.5.5']);
+
+		$this->assertRedirect(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'index']);
+		$this->assertSame(0, $Captchas->find()->where(['ip' => '5.5.5.5'])->count());
+		$this->assertSame(1, $Captchas->find()->where(['ip' => '6.6.6.6'])->count());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testClearRateLimitWipesCacheKeys() {
+		Configure::write('Captcha.verifyRateLimit', [
+			'enabled' => true,
+			'maxFailures' => 5,
+			'window' => 600,
+			'scope' => 'ip_session',
+			'cache' => 'captcha_admin_test',
+		]);
+
+		$Captchas = $this->getTableLocator()->get('Captcha.Captchas');
+		$row = $Captchas->newEntity([
+			'uuid' => '66666666-6666-4666-8666-666666666666',
+			'session_id' => 'sess-known',
+			'ip' => '7.7.7.7',
+			'result' => '1',
+			'solved' => false,
+		]);
+		$Captchas->saveOrFail($row);
+
+		$key = RateLimitKey::build('7.7.7.7', 'sess-known', 'ip_session', 600);
+		Cache::write($key, 99, 'captcha_admin_test');
+		$this->assertSame(99, Cache::read($key, 'captcha_admin_test'));
+
+		$this->enableRetainFlashMessages();
+		$this->post(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'clearRateLimit', '7.7.7.7']);
+
+		$this->assertRedirect(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'index']);
+		$this->assertNull(Cache::read($key, 'captcha_admin_test'));
+	}
+
+}

--- a/tests/TestCase/Model/Behavior/CaptchaBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/CaptchaBehaviorTest.php
@@ -383,4 +383,87 @@ class CaptchaBehaviorTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testCorrectAnswerMarksSolvedTrue() {
+		$captcha = $this->Captchas->newEntity([
+			'uuid' => Text::uuid(),
+			'result' => 51,
+			'ip' => '127.0.0.1',
+			'session_id' => $this->request->getSession()->id() ?: 'test',
+			'created' => new DateTime('- 1 hour'),
+			'modified' => new DateTime('- 1 hour'),
+		]);
+		$this->assertTrue((bool)$this->Captchas->save($captcha));
+
+		$comment = $this->Comments->newEntity([
+			'comment' => 'Foo',
+			'captcha_uuid' => $captcha->uuid,
+			'captcha_result' => 51,
+			'email_homepage' => '',
+		]);
+		$this->assertTrue((bool)$this->Comments->save($comment));
+
+		$captcha = $this->Captchas->get($captcha->id);
+		$this->assertTrue($captcha->solved);
+		$this->assertNotEmpty($captcha->used);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testWrongAnswerMarksSolvedFalse() {
+		$captcha = $this->Captchas->newEntity([
+			'uuid' => Text::uuid(),
+			'result' => 61,
+			'ip' => '127.0.0.1',
+			'session_id' => $this->request->getSession()->id() ?: 'test',
+			'created' => new DateTime('- 1 hour'),
+			'modified' => new DateTime('- 1 hour'),
+		]);
+		$this->assertTrue((bool)$this->Captchas->save($captcha));
+
+		$comment = $this->Comments->newEntity([
+			'comment' => 'Foo',
+			'captcha_uuid' => $captcha->uuid,
+			'captcha_result' => 99,
+			'email_homepage' => '',
+		]);
+		$this->assertFalse((bool)$this->Comments->save($comment));
+
+		$captcha = $this->Captchas->get($captcha->id);
+		$this->assertFalse($captcha->solved);
+		$this->assertNotEmpty($captcha->used);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testReplayDoesNotChangeSolved() {
+		$captcha = $this->Captchas->newEntity([
+			'uuid' => Text::uuid(),
+			'result' => 71,
+			'ip' => '127.0.0.1',
+			'session_id' => $this->request->getSession()->id() ?: 'test',
+			'created' => new DateTime('- 1 hour'),
+			'modified' => new DateTime('- 1 hour'),
+		]);
+		$this->assertTrue((bool)$this->Captchas->save($captcha));
+
+		$data = [
+			'comment' => 'Foo',
+			'captcha_uuid' => $captcha->uuid,
+			'captcha_result' => 71,
+			'email_homepage' => '',
+		];
+		$this->assertTrue((bool)$this->Comments->save($this->Comments->newEntity($data)));
+
+		$data['captcha_result'] = 99;
+		$this->assertFalse((bool)$this->Comments->save($this->Comments->newEntity($data)));
+
+		$captcha = $this->Captchas->get($captcha->id);
+		$this->assertTrue($captcha->solved, 'Successful solve must not be overwritten by a later replay attempt');
+	}
+
 }


### PR DESCRIPTION
## Summary

Adds a self-contained admin backend under `/admin/captcha/` giving operators a one-screen view of captcha health, abuse signals, and per-IP maintenance — same conventions as cakephp-queue and CakePHP-DatabaseLog.

## Highlights

- **Routing** — `Captcha.adminPrefix` (default `Admin`) + `Captcha.adminRoutePath` (default `/captcha`). Default URL `/admin/captcha/` matches the queue / databaselog house style.
- **Auth** — deny by default. Register a `Captcha.adminAccess` `Closure(ServerRequest): bool` to grant access. Diverges deliberately from queue/databaselog: this plugin is security-adjacent and accidental exposure is harmful.
- **Layout** — plugin-owned Bootstrap 5 layout `Captcha.captcha-admin`. Opt out via `Captcha.adminLayout` (`false` = host layout, string = custom).
- **Schema delta** — new nullable `solved` column on `captchas`. Composite index `(solved, created)`. Set in `CaptchaBehavior::validateCaptchaResult` immediately before `markUsed`, so post-hoc the table can answer 'solved correctly vs wrong'. Existing rows remain `null`.
- **`Captcha\Cache\RateLimitKey`** — extracted util for the verify rate-limit cache key. Behavior now delegates; admin uses the same helper for `clearRateLimit`. No behavior change.
- **`Admin\CaptchaController`** — dashboard (stat tiles, hourly heatmap, snapshot), config readout, engine list, engine preview, manual cleanup, hard reset.
- **`Admin\IpsController`** — leaderboards (issued / solved / failed / currently rate-limited, 24h or 7d), per-IP detail page, per-IP reset, per-IP rate-limit cache wipe.
- **'Currently rate-limited'** is derived from the captchas table directly (`solved = false AND created > now - window` grouped by IP) — cache keys are sha1-bucketed and not reversible, and not every backend supports iteration.
- **Heatmap** aggregated in PHP for cross-DB portability (MySQL/Postgres/SQLite all differ on hour-extraction syntax).
- **Tests** — `RateLimitKeyTest` (6), `CaptchaBehaviorTest` extension (3), `Admin/CaptchaControllerTest` (9), `Admin/IpsControllerTest` (6). Full suite is green: 47 / 47.
- **Docs** — new `docs/Admin.md` covering setup, auth, every page, plus the rate-limit derivation note. Linked from `README.md` and `docs/README.md`.

## Verification

- `phpunit` — 47 tests, 140 assertions, all green
- `phpstan` — no errors at level 8
- `phpcs` — clean