### PR TITLE
Harden admin backend: SRI, GET-only display, IP input validation

### DIFF
--- a/src/Controller/Admin/IpsController.php
+++ b/src/Controller/Admin/IpsController.php
@@ -5,6 +5,7 @@ namespace Captcha\Controller\Admin;
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\I18n\DateTime;
 use Captcha\Cache\RateLimitKey;
 
@@ -54,7 +55,7 @@ class IpsController extends CaptchaAdminAppController {
 	 * @return void
 	 */
 	public function view(?string $ip = null): void {
-		$ip = (string)$ip;
+		$ip = $this->assertValidIp($ip);
 		$query = $this->Captchas->find()
 			->where(['ip' => $ip])
 			->orderBy(['created' => 'DESC']);
@@ -87,7 +88,7 @@ class IpsController extends CaptchaAdminAppController {
 	 */
 	public function reset(?string $ip = null) {
 		$this->request->allowMethod('post');
-		$ip = (string)$ip;
+		$ip = $this->assertValidIp($ip);
 
 		$count = $this->Captchas->reset($ip);
 
@@ -103,7 +104,7 @@ class IpsController extends CaptchaAdminAppController {
 	 */
 	public function clearRateLimit(?string $ip = null) {
 		$this->request->allowMethod('post');
-		$ip = (string)$ip;
+		$ip = $this->assertValidIp($ip);
 
 		$rl = (array)Configure::read('Captcha.verifyRateLimit');
 		$cache = (string)($rl['cache'] ?? 'default');
@@ -170,6 +171,27 @@ class IpsController extends CaptchaAdminAppController {
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Validate the IP path argument as a real IPv4/IPv6 address.
+	 *
+	 * Defense-in-depth against arbitrary path strings being reflected into
+	 * queries, cache keys and flash messages.
+	 *
+	 * @param string|null $ip
+	 *
+	 * @throws \Cake\Http\Exception\BadRequestException
+	 *
+	 * @return string Normalized IP string.
+	 */
+	protected function assertValidIp(?string $ip): string {
+		$ip = (string)$ip;
+		if ($ip === '' || filter_var($ip, FILTER_VALIDATE_IP) === false) {
+			throw new BadRequestException(__d('captcha', 'Invalid IP address.'));
+		}
+
+		return $ip;
 	}
 
 	/**

--- a/src/Controller/CaptchaController.php
+++ b/src/Controller/CaptchaController.php
@@ -54,6 +54,8 @@ class CaptchaController extends AppController {
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function display($id = null) {
+		$this->request->allowMethod('get');
+
 		if ($id === null) {
 			$captcha = new Captcha();
 		} else {

--- a/templates/layout/captcha-admin.php
+++ b/templates/layout/captcha-admin.php
@@ -11,8 +11,16 @@
 	<meta charset="utf-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 	<title><?= $this->fetch('title') ?: __d('captcha', 'Captcha Admin') ?></title>
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css">
+	<link rel="stylesheet"
+		href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+		integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+		crossorigin="anonymous"
+		referrerpolicy="no-referrer">
+	<link rel="stylesheet"
+		href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"
+		integrity="sha384-PPIZEGYM1v8zp5Py7UjFb79S58UeqCL9pYVnVPURKEqvioPROaVAJKKLzvH2rDnI"
+		crossorigin="anonymous"
+		referrerpolicy="no-referrer">
 	<style>
 		body { background: #f5f7fa; }
 		.captcha-admin-nav { background: #1f2937; }
@@ -58,6 +66,9 @@
 	<?= $this->fetch('content') ?>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+	integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+	crossorigin="anonymous"
+	referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/tests/TestCase/Controller/Admin/IpsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/IpsControllerTest.php
@@ -5,6 +5,7 @@ namespace Captcha\Test\TestCase\Controller\Admin;
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -133,6 +134,36 @@ class IpsControllerTest extends TestCase {
 
 		$this->assertResponseOk();
 		$this->assertResponseContains(__d('captcha', 'No captchas seen for this IP.'));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testViewRejectsNonIpString() {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->get(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'view', 'not-an-ip']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testResetRejectsNonIpString() {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->post(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'reset', 'bogus-value']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testClearRateLimitRejectsNonIpString() {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(BadRequestException::class);
+
+		$this->post(['plugin' => 'Captcha', 'prefix' => 'Admin', 'controller' => 'Ips', 'action' => 'clearRateLimit', 'totally-not-ip']);
 	}
 
 	/**

--- a/tests/TestCase/Controller/CaptchaControllerTest.php
+++ b/tests/TestCase/Controller/CaptchaControllerTest.php
@@ -3,6 +3,7 @@
 namespace Captcha\Test\TestCase\Controller;
 
 use Cake\Core\Configure;
+use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -72,6 +73,17 @@ class CaptchaControllerTest extends TestCase {
 		$this->assertHeaderContains('Pragma', 'no-cache');
 		$this->assertHeaderContains('Expires', '0');
 		$this->assertResponseNotEmpty();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDisplayRejectsPost() {
+		$this->disableErrorHandlerMiddleware();
+		$this->expectException(MethodNotAllowedException::class);
+
+		$id = '11111111-1111-4111-8111-111111111111';
+		$this->post(['plugin' => 'Captcha', 'controller' => 'Captcha', 'action' => 'display', $id]);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Three high-priority security hardening fixes for the freshly added captcha admin backend.

### 1. SRI for Bootstrap and FontAwesome CDN assets

`templates/layout/captcha-admin.php:14-15,61` previously loaded Bootstrap 5.3.3 CSS/JS and FontAwesome 6.5.2 from `cdn.jsdelivr.net` with no `integrity` attribute. A compromised or man-in-the-middle CDN response would execute attacker-controlled JavaScript inside the captcha admin (a privileged surface gated by `Captcha.adminAccess`).

Pinned each external asset to its SHA-384 SRI hash, added `crossorigin="anonymous"` and `referrerpolicy="no-referrer"`. Browsers now refuse mismatched payloads and stop leaking the admin URL as Referer.

### 2. GET-only `display()` action

`src/Controller/CaptchaController.php:56` did not enforce HTTP method. Because `Security::validatePost` is intentionally disabled on this controller and CSRF is GET-exempt, a same-origin POST to `/captcha/display/UUID` could re-enter `Preparer::prepare()` and overwrite a victim's captcha state. Added `\$this->request->allowMethod('get');` at the top of the action.

### 3. Validate IP path argument in `IpsController`

`src/Controller/Admin/IpsController.php` previously cast the URL segment straight to `(string)` in `view()`, `reset()`, and `clearRateLimit()`. The ORM parameter-binds the value, so SQL injection is not a vector, but arbitrary strings still reach `h(\$ip)` reflection, flash placeholder substitution, log lines, and rate-limit cache keys (log poisoning, control characters, very long strings). Added an `assertValidIp()` helper that throws `BadRequestException` when `filter_var(..., FILTER_VALIDATE_IP)` rejects the input.

## Tests

- `testDisplayRejectsPost` asserts `MethodNotAllowedException` on POST.
- `testViewRejectsNonIpString`, `testResetRejectsNonIpString`, `testClearRateLimitRejectsNonIpString` assert `BadRequestException` on non-IP path arguments.
- Existing 47 tests still pass.

## Verification

- `vendor/bin/phpunit` — 51 tests, 144 assertions, OK.
- `vendor/bin/phpstan analyze --no-progress` — No errors.
- `vendor/bin/phpcs src/ tests/ templates/layout/captcha-admin.php` — No errors on touched files.